### PR TITLE
Improved NTLM Metadata Collection for SMB

### DIFF
--- a/pkg/plugins/services/smb/smb.go
+++ b/pkg/plugins/services/smb/smb.go
@@ -185,7 +185,7 @@ func DetectSMBv2(conn net.Conn, timeout time.Duration) (*map[string]any, error) 
 	info["signingEnabled"] = strconv.FormatBool(signingEnabled)
 	info["signingRequired"] = strconv.FormatBool(signingRequired)
 
-	/**
+	/**f
 	 * At this point, we know SMBv2 is detected.
 	 * Below, we try to obtain more metadata via session setup request w/ NTLM auth
 	 */
@@ -295,9 +295,11 @@ func DetectSMBv2(conn net.Conn, timeout time.Duration) (*map[string]any, error) 
 
 	// Parse: TargetInfo
 	AvIDMap := map[uint16]string{
-		1: "computerName",
-		2: "domainName",
-		3: "fqdn", // DNS Computer Name
+		1: "netbiosComputerName",
+		2: "netbiosDomainName",
+		3: "dnsComputerName",
+		4: "dnsDomainName",
+		5: "forestName", // MsvAvDnsTreeName
 	}
 	type AVPair struct {
 		AvID  uint16

--- a/pkg/plugins/services/smb/smb.go
+++ b/pkg/plugins/services/smb/smb.go
@@ -185,7 +185,7 @@ func DetectSMBv2(conn net.Conn, timeout time.Duration) (*map[string]any, error) 
 	info["signingEnabled"] = strconv.FormatBool(signingEnabled)
 	info["signingRequired"] = strconv.FormatBool(signingRequired)
 
-	/**f
+	/**
 	 * At this point, we know SMBv2 is detected.
 	 * Below, we try to obtain more metadata via session setup request w/ NTLM auth
 	 */


### PR DESCRIPTION
Improved metadata collection for SMB by capturing additional information from the NTLM_CHALLENGE message returned by the server.