### PR TITLE
Added Length Check to Before Accessing Array

### DIFF
--- a/pkg/plugins/services/oracledb/oracle.go
+++ b/pkg/plugins/services/oracledb/oracle.go
@@ -195,6 +195,11 @@ func isOracleDBRunning(response []byte) bool {
 		0x50, 0x3d, 0x29, 0x28, 0x56, 0x53, 0x4e, 0x4e,
 		0x55, 0x4d, 0x3d,
 	}
+
+	if len(response) < 27 {
+		return false
+	}
+
 	responseCode := int(response[4])
 
 	// This should always be a response code of 4 (rejection),


### PR DESCRIPTION
Fixed a crash in the oracle database fingerprinting plugin where the response length returned by the server was not being checked properly.