### PR TITLE
Remove Anon Login, as FTP code never checks for anon login

### DIFF
--- a/pkg/plugins/types.go
+++ b/pkg/plugins/types.go
@@ -405,7 +405,6 @@ func (e ServiceRedis) Type() string { return ProtoRedis }
 
 type ServiceFTP struct {
 	Banner         string `json:"banner"`
-	AnonymousLogin bool   `json:"anonymousLogin"`
 }
 
 func (e ServiceFTP) Type() string { return ProtoFTP }


### PR DESCRIPTION
Hi great project! 

I was worried that the scanner tried to log into FTP servers when I saw this.
```go
AnonymousLogin bool   `json:"anonymousLogin"`
```
After reviewing the FTP module the check is never performed and the field is never filled, so I think it makes sense to delete it from the results struct.

```go
func (p *FTPPlugin) Run(conn net.Conn, timeout time.Duration, target plugins.Target) (*plugins.Service, error) {
	response, err := utils.Recv(conn, timeout)
	if err != nil {
		return nil, err
	}
	if len(response) == 0 {
		return nil, nil
	}

	matches := ftpResponse.FindStringSubmatch(string(response))
	if matches == nil {
		return nil, nil
	}

	payload := plugins.ServiceFTP{
		Banner: string(response),
	}

	return plugins.CreateServiceFrom(target, payload, false, "", plugins.TCP), nil
}
```