### PR TITLE
fix: prevent panic on truncated RPC responses

### DIFF
--- a/pkg/plugins/services/linuxrpc/linuxrpc.go
+++ b/pkg/plugins/services/linuxrpc/linuxrpc.go
@@ -125,7 +125,9 @@ func parseRPCInfo(response []byte, lookupResponse *plugins.ServiceRPC) error {
 
 	for valueFollows == 1 {
 		tmp := plugins.RPCB{}
-		if len(response) < 0x20 {
+
+		// Need at least 12 bytes for program (4) + version (4) + networkIDLen (4)
+		if len(response) < 12 {
 			return nil
 		}
 
@@ -138,23 +140,40 @@ func parseRPCInfo(response []byte, lookupResponse *plugins.ServiceRPC) error {
 			networkIDLen++
 		}
 		response = response[4:]
+		if len(response) < networkIDLen {
+			return nil
+		}
 		tmp.Protocol = string(response[0:networkIDLen])
 		response = response[networkIDLen:]
+		if len(response) < 4 {
+			return nil
+		}
 		addressLen := int(binary.BigEndian.Uint32(response[0:4]))
 		for addressLen%4 != 0 {
 			addressLen++
 		}
 		response = response[4:]
+		if len(response) < addressLen {
+			return nil
+		}
 		tmp.Address = string(response[0:addressLen])
 		response = response[addressLen:]
+		if len(response) < 4 {
+			return nil
+		}
 		ownerLen := int(binary.BigEndian.Uint32(response[0:4]))
 		for ownerLen%4 != 0 {
 			ownerLen++
 		}
 		response = response[4:]
+		if len(response) < ownerLen {
+			return nil
+		}
 		tmp.Owner = string(response[0:ownerLen])
 		response = response[ownerLen:]
-
+		if len(response) < 4 {
+			return nil
+		}
 		valueFollows = int(binary.BigEndian.Uint32(response[0:4]))
 		response = response[4:]
 

--- a/pkg/plugins/services/linuxrpc/linuxrpc_test.go
+++ b/pkg/plugins/services/linuxrpc/linuxrpc_test.go
@@ -47,7 +47,7 @@ func TestRPC(t *testing.T) {
 			t.Parallel()
 			err := test.RunTest(t, tc, p)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Errorf("%s", err.Error())
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Fix a panic in `parseRPCInfo` caused by truncated or malformed RPC dump responses. The function slices into variable-length fields (protocol, address, owner) without checking remaining buffer length, causing `slice bounds out of range` when a response is shorter than expected.

This crashes the entire fingerprintx process, killing service detection for all remaining targets.

### Stack trace from production
```
panic: runtime error: slice bounds out of range [4:0]

goroutine 1 [running]:
github.com/praetorian-inc/fingerprintx/pkg/plugins/services/linuxrpc.parseRPCInfo(...)
    linuxrpc.go:154
```

## Changes
- Add bounds checks before each variable-length field access in the parse loop
- Gracefully return partial results instead of panicking on truncated data
- Fix pre-existing `go vet` warning (non-constant format string in test)

## Test plan
- [x] Existing `TestRPC/alpine-nfs` passes
- [x] `go vet` clean on the package